### PR TITLE
Add google analytics tracking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,7 @@ disqus:
 #google_analytics: UA-43339302-11
 
 # For newer "GA4" analytics, use the following instead of the "UA" entry above
-#google_analytics_ga4: G-GABC1DEFG
+google_analytics_ga4: G-NQ9259P3ZZ
 
 # Your website URL (e.g. http://amitmerchant1990.github.io or http://www.amitmerchant.com)
 # Used for Sitemap.xml and your RSS feed


### PR DESCRIPTION
This uses a Google Analytics ID that I created, I believe that I can grant permissions for others to view the analytics pages. 

One reason for doing this is to get a better idea of how people use the site, e.g. certain popular pages may be buried, and could be surfaced in the main nav bar.