### PR TITLE
Update link to paper style files

### DIFF
--- a/cfp.md
+++ b/cfp.md
@@ -122,7 +122,7 @@ ARR provides a [submission checklist](/authorchecklist). The checklist is intend
 
 Submission is electronic, using the OpenReview.net platform. All long, short and theme papers must follow the [ACL Author Guidelines](https://www.aclweb.org/adminwiki/index.php?title=ACL_Author_Guidelines). [Here](/submissionform) are the paper submission form fields for your reference.
  
-Paper submissions must use the official ACL style templates, which are available as an [Overleaf template](https://www.overleaf.com/read/crtcwgxzjskr) and also [downloadable directly](https://github.com/acl-org/ACLPUB/tree/master/templates)  (Latex and Word). Please follow the paper formatting guidelines general to "\*ACL" conferences available [here](https://acl-org.github.io/ACLPUB/formatting.html).
+Paper submissions must use the official ACL style templates, which are available as an [Overleaf template](https://www.overleaf.com/read/crtcwgxzjskr) and also [downloadable directly](https://github.com/acl-org/acl-style-files)  (LaTeX and Word). Please follow the paper formatting guidelines general to "\*ACL" conferences available [here](https://acl-org.github.io/ACLPUB/formatting.html).
 Authors may not modify these style files or use templates designed for other conferences. Submissions that do not conform to the required styles, including paper size, margin width, and font size restrictions, will be rejected without review. 
  
 [Here](/reviewform) is the current version of the review form, and [here](/actioneditorform) is the current version of the action editor meta-review form. These forms will be re-assessed and updated periodically.

--- a/responsibleNLPresearch.md
+++ b/responsibleNLPresearch.md
@@ -5,7 +5,7 @@ We expect authors to show that they follow best practices in two ways:
 1. by filling in the checklist to ensure that best practices are put in place when using, creating or providing assets,
 2. by including a discussion in the paper about any potential positive or negative societal impacts and any limitations of the work. The guidelines below provide additional information about what should be discussed.
 
-The checklist exists as a [fillable PDF](https://aclrollingreview.org/Responsible_NLP_Research_Checklist___Fillable_form.pdf) and as [LaTex source](https://aclrollingreview.org/Responsible%20NLP%20Research%20Checklist%20-%20Fillable%20form.zip)
+The checklist exists as a [fillable PDF](https://aclrollingreview.org/Responsible_NLP_Research_Checklist___Fillable_form.pdf) and as [LaTeX source](https://aclrollingreview.org/Responsible%20NLP%20Research%20Checklist%20-%20Fillable%20form.zip)
 
 Reviewers will be asked to use the checklist as one of the factors in their evaluation.
 


### PR DESCRIPTION
Recently @mjpost and I moved the ACL LaTeX/Word style files to a new repository. This PR updates the links on the ARR website to point to the new location.
