### PR TITLE
UM-IoS Workshop 2022

### DIFF
--- a/dates.md
+++ b/dates.md
@@ -53,3 +53,4 @@ Current publication venues participating in ARR are listed below. If you represe
 | [TRAC 2022](https://sites.google.com/view/trac2022/) | 31 July 2022 | 
 | AACL-IJCNLP 2022 | 7 August 2022 |
 | [CASE 2022](https://emw.ku.edu.tr/case-2022/) | October 2, 2022 |
+| [UM-IoS 2022](https://induction-of-structure.github.io/emnlp2022/) | October 2, 2022 |


### PR DESCRIPTION
The first Unimodal and Multimodal Induction of Linguistic Structures Workshop (UM-IoS) will be held in conjunction with EMNLP 2022. We would like to subscribe to ARR in Hybrid setup.