### PR TITLE
Added IJCNLP-AACL 2023

### DIFF
--- a/dates.md
+++ b/dates.md
@@ -29,6 +29,7 @@ Current publication venues participating in ARR are listed below. If you represe
 | [LAW 2023](https://sigann.github.io/LAW-XVII-2023) | February 15th, 2023 | May 10th, 2023 |
 | [INLG 2023](https://inlg2023.github.io/) | April 15th, 2023 | June 15, 2023 |
 | [SIGDIAL 2023](https://2023.sigdial.org/) | April 15th, 2023 | June 19th, 2023 |
+| [IJCNLP-AACL 2023](http://www.ijcnlp-aacl2023.org/) | June 15th, 2023 | August 15th, 2023 |
 
 
 ## Past Venues that Accepted ARR Submissions


### PR DESCRIPTION
IJCNLP-AACL 2023 would like to subscribe to ARR. We have added the venue name with the website URL and the planned commitment deadline. We appreciate it if you could merge the request. 

PC chairs of IJCNLP-AACL 2023