### PR TITLE
Fix responsible NLP research checklist

### DIFF
--- a/static/responsibleNLPresearch.tex
+++ b/static/responsibleNLPresearch.tex
@@ -265,7 +265,7 @@ If you answer {\bf Yes}, provide the section number; if you answer {\bf No}, pro
 If you answer {\bf Yes}, answer the question below; if you answer {\bf No}, you can skip the rest of this section. \\[0.3cm]
 \begin{Form}
 \begin{tabular}{l}
-    \cm{hummanAnnotators}{Yes,No}{}\\
+    \cm{aiAssistants}{Yes,No}{}\\
 \end{tabular}
 \end{Form}
 
@@ -273,8 +273,8 @@ If you answer {\bf Yes}, answer the question below; if you answer {\bf No}, you 
 If you answer {\bf Yes}, provide the section number; if you answer {\bf No}, provide a justification. \\[0.3cm]
 \begin{Form}
 \begin{tabular}{l}
-    \cm{annotator}{Yes,No,N/A}{}\\[0.2cm]
-    \tf{annotatorJustification}{}
+    \cm{aiAssistantsInformation}{Yes,No,N/A}{}\\[0.2cm]
+    \tf{aiAssistantsInformationJustification}{}
 \end{tabular}
 \end{Form} \\[0.3cm]
 


### PR DESCRIPTION
When completing the [responsible NLP research checklist](https://aclrollingreview.org/responsibleNLPresearch/), question pairs (D, E) and (D5, E1) overwrite each other. This is because the new AI assistant questions inadvertently use existing labels.

This pull request addresses the issue by updating the AI assistant questions with unique labels. Please note that the choice of these labels was arbitrary, following the existing convention in the file.