### PR TITLE
Added LAW 2024

### DIFF
--- a/dates.md
+++ b/dates.md
@@ -35,6 +35,7 @@ Current publication venues participating in ARR are listed below. If you represe
 |---------------------|------------|------------|
 | [NEJLT volume 9 (2)](https://www.nejlt.org/) | August 15th, 2023 | November 1st, 2023 |
 | [EACL 2024](https://2024.eacl.org/) | October 15th, 2023 | December 20th, 2023 |
+| [LAW 2024](https://sigann.github.io/LAW-XVIII-2024/) | October 15th, 2023 | January 17th, 2024 |
 | [NAACL 2024](https://2024.naacl.org/) | December 15th, 2023 | February 20th, 2024 |
 | [ACL 2024](https://2024.aclweb.org/) | February 15th, 2024 | TBC |
 


### PR DESCRIPTION
added the dates for the Linguistic Annotation Workshop (LAW)  to the table in dates.md