### PR TITLE
Add EACL 2024 SRW

### DIFF
--- a/dates.md
+++ b/dates.md
@@ -35,6 +35,7 @@ Current publication venues participating in ARR are listed below. If you represe
 |---------------------|------------|------------|
 | [NEJLT volume 9 (2)](https://www.nejlt.org/) | August 15th, 2023 | November 1st, 2023 |
 | [EACL 2024 main](https://2024.eacl.org/), and [commitment](https://openreview.net/group?id=eacl.org/EACL/2024/Conference) | October 15th, 2023 | December 20th, 2023 |
+| [EACL 2024 SRW](https://sites.google.com/view/eacl2024srw) | October 15th, 2023 | January 17th, 2024 |
 | [LAW 2024](https://sigann.github.io/LAW-XVIII-2024/) | October 15th, 2023 | January 17th, 2024 |
 | [WNUT 2024](http://noisy-text.github.io/2024/) | October 15th, 2023 | January 17th, 2024 |
 | [NAACL 2024](https://2024.naacl.org/) | December 15th, 2023 | February 20th, 2024 |


### PR DESCRIPTION
Add the EACL 2024 Student Research Workshop to the venues accepting ARR commitment.