### PR TITLE
removal of anonymity period (#108)

### DIFF
--- a/authorchecklist.md
+++ b/authorchecklist.md
@@ -25,7 +25,7 @@ Some key items for first time authors:
 
 ## Anonymization and Citation
 
-Please refer to [this page](https://www.aclweb.org/adminwiki/index.php?title=ACL_Policies_for_Submission,_Review_and_Citation) for the ACL policies for submission, review and citation. Most of this information is also covered in the template and format guidelines linked above.
+Please refer to [this page](https://www.aclweb.org/adminwiki/index.php?title=ACL_Policies_for_Review_and_Citation) for the ACL policies for review and citation. Most of this information is also covered in the template and format guidelines linked above.
 
 ## Responsible NLP Research
 

--- a/authors.md
+++ b/authors.md
@@ -55,13 +55,12 @@ All submitted materials must be **anonymized**. Submissions and any supplementar
 
 Before submitting, ensure that:
 - Your paper is not already under review, published, or on track to be published at any archival venue. ("Under review" includes papers for which prior ARR reviews have been committed to a venue, and a decision is pending—see [Step 5](#step5).)
-- You have not posted a non-anonymous preprint of your paper or widely advertised it in the 1 month prior to the submission deadline. (See the [ACL Policies on Submission, Review and Citation](https://www.aclweb.org/adminwiki/index.php/ACL_Policies_for_Submission,_Review_and_Citation) and the [FAQ below](#anon))
 - Your paper satisfies everything in the [author checklist](/authorchecklist)
 
 At the time of submission you may opt to have ARR publish your paper as an **anonymous preprint**. These will remain anonymous during and after the review process. If you wish to remove an anonymous preprint, please contact the ARR editors (see [People](/people)).
 
 # Step 2: Wait for reviews {#step2}
-As soon as you have submitted your paper it is considered **under review** by ARR. You may not submit the paper elsewhere during this period, nor submit/update a non-anonymous preprint or widely publicize the work while it is under review.
+As soon as you have submitted your paper it is considered **under review** by ARR. You may not submit the paper elsewhere during this period.
 
 You may **withdraw** your submission during this period (before it receives a meta-review), but if you do so more than 48 hours after the submission deadline, your paper will be ineligible for resubmission in the next cycle. Contact the editors if you encounter special circumstances and are not sure whether withdrawal is appropriate. To withdraw, log into OpenReview, select your submission and then click on the "trash can" icon in the top right.
 
@@ -77,7 +76,7 @@ Once the final reviews (including the meta-review) are delivered, you will know 
 You have several choices for the next step of the paper:
 
 - Quickly address reviewer feedback, and submit a revision to the **next ARR review deadline** (~1 week). → [Step 4](#step4)
-- Spend more time on revisions and submit to **a subsequent ARR deadline** (2+ months). Note that with this option, there is a period when your paper is not under review. You are allowed to release a preprint or discuss it publicly in that period, up until a month before you submit again. → [Step 4](#step4)
+- Spend more time on revisions and submit to **a subsequent ARR deadline** (2+ months). → [Step 4](#step4)
 - **Commit the reviews to an ARR venue** for a decision on acceptance. → [Step 5](#step5)
 - Submit for **direct (i.e. non-ARR) review** by a venue. If you are submitting to a venue that has both direct submissions and ARR submissions, see their policies for how to go from ARR reviewing to being directly reviewed. Note that venues may have other restrictions: for example, [TACL](https://transacl.org/index.php/tacl/about/submissions) requires a 9 month gap between submission to ARR and submission to TACL.
 
@@ -115,8 +114,6 @@ Commitment occurs through a submission form set up by the PCs of the venue (e.g.
 
 Different venues have different commitment deadlines, and therefore, different commitment periods when the paper is under consideration by a venue. ARR does not place any restrictions on committing to multiple venues simultaneously, or committing to one venue and submitting for direct review at another venue. However, venues typically do not permit these types of dual commitments / submissions.
 
-The commitment period is also subject to **anonymity** requirements: during the commitment period and for the 1 month prior to the commitment deadline, you may not submit/update a nonanonymous preprint of the paper or publicize it widely.
-
 The commitment phase ends when the paper is no longer under consideration by any venue—either due to withdrawal or due to receiving a decision of acceptance or rejection.
 
 If the paper is accepted, it is no longer eligible for further rounds of review at ARR. (Whether you can commit to additional venues is up to the policies of those venues.) → [Step 6](#step6)
@@ -149,25 +146,9 @@ A: Please contact: `support at aclrollingreview.org`
 ## Anonymity {#anon}
 
 **Q: What are the requirements of the anonymity policy for authors?** <br />
-A: ARR follows [the ACL Policies for Submission, Review and Citation](https://www.aclweb.org/adminwiki/index.php/ACL_Policies_for_Submission,_Review_and_Citation). For each review cycle and commitment process there is an anonymity period (see question below for timing). During the anonymity periods, ARR submissions may not be released online in a non-anonymized form (e.g. via arXiv or on a personal website). Non-anonymous preprints that were published before the start of the anonymity period may not be updated until the meta-reviews are released for the cycle. The only exception is for the purpose of correcting names, in which case the EICs should be notified per ACL policy. The existence of non-anonymous preprints must be disclosed in the submission form.
+A: ARR follows [the ACL Policies for Review and Citation](https://www.aclweb.org/adminwiki/index.php/ACL_Policies_for_Review_and_Citation). Submissions must be anonymized as detailed in [Step 1](#step1).
 
-ARR permits talks about work under review in small groups, such as colloquia and workshops, but we ask you not to advertise the preprint (or the content of such talks) on social media, blog about the work, or have it covered in the media during the anonymity period. Anonymous preprints can be posted after the start of the anonymity period, but likewise should not be advertised by their authors or their close colleagues, as that can compromise the review process. If you wish to make an anonymous preprint, ARR provides an option for you to do so at submission. Other anonymous preprint servers are also permitted.
-
-See [the ACL policy](https://www.aclweb.org/adminwiki/index.php/ACL_Policies_for_Submission,_Review_and_Citation) for further details on what is and is not permitted.
-
-See [Step 1](#step1) for details on anonymity requirements for the paper itself at submission time.
-
-**Q: When do these anonymity requirements apply?** <br />
-A: The ACL anonymity rules apply to both the review process and the commitment process.
-
-The anonymity period for the review period starts one month before the deadline for the cycle and ends once either meta-reviews have been released, the paper is withdrawn, or the paper is desk-rejected. For example, for the June 2023 cycle, the submission deadline was June 15th and meta-reviews were returned by August 15th, so the anonymity period started on May 15th and ended on August 15th.
-
-For commitment, the anonymity policy is up to the venue. Typically, the anonymity period for commitment starts one month before the commitment deadline and ends once decisions are released or the paper is withdrawn. For example, for ACL 2023, the commitment deadline was March 17th and notifications were May 1st, so the anonymity period started on February 17th and ended on May 1st.
-
-Note, for arXiv, the timings above refer to when your paper is submitted to arXiv (not the date it appears on arXiv). We understand that in some cases this means the timestamp shown on your paper may be inside the anonymity period.
-
-**Q: I submitted to ICLR, but want to withdraw my paper to submit to ARR. This withdrawal will cause my paper to become deanonymized. Is that OK?** <br />
-A: If a non-anonymous version of the paper was made publicly available before the ARR anonymity period, it is OK to withdraw from ICLR and submit to ARR. However, if de-anonymization on withdrawal from ICLR results in the paper being de-anonymized for the first time during the anonymity period, the paper would violate the ARR anonymity policies.
+Beginning with the February 15, 2024 ARR deadlines, there is no anonymity period or limitation on posting or discussing non-anonymous preprints while the work is under peer review.
 
 ## Contributing to the Paper and Review Dataset
 

--- a/cfp.md
+++ b/cfp.md
@@ -59,22 +59,6 @@ Short paper submissions must describe original and unpublished work. Please note
 
 Short papers may consist of up to four (4) pages of content, plus up to one page for the ethical considerations/limitations section (see below), plus unlimited pages of references. Submissions that exceed the length requirements will be desk rejected.
 
-### Anonymity Period
-
-ACL has [policies for submission, review, and citation](https://www.aclweb.org/adminwiki/index.php?title=ACL_Policies_for_Submission,_Review_and_Citation) designed to protect the integrity of two-way anonymized review and ensure that submissions are reviewed fairly. A paper can only be (re)submitted to ARR if no deanonymized preprint has been posted in the month prior to submission. Also, a paper can only be submitted to a venue if no deanonymized preprint has been posted in the month prior to submission. Submissions will be rejected if not properly anonymized.
-
-If authors would like to post a non-anonymous preprint or otherwise deanonymize their submission, they will have to withdraw their submission from ARR, a one-step process in OpenReview. Note, however, that if authors withdraw more than 48 hours after the submission deadline, they can’t resubmit until the 2nd following ARR round. Withdrawing while the reviewing process has been launched is a waste of time and effort of many people. Once a submission is withdrawn, it is removed from that cycle’s reviewing pool. Authors may then make a new submission (subject to the one month anonymity waiting period) which would potentially go to a new AE and new reviewers.
-
-Please note that anonymity should be maintained during the entire revision process - until meta reviews have been posted. Also note that venues have anonymity policies for the commitment proces, and the timing may overlap, e.g., in 2023, the October cycle was Oct 15 - Dec 15, and EACL commitment was Dec 20, and so the anonymity period for commitment overlapped with the anonymity period for the cycle. It is the author’s responsibility to ensure that anonymity is kept. Submissions that violate this requirement will be desk rejected.
-
-Further info:
-
-- Authors may allow their anonymized submission to be publicly available on OpenReview while it is under ARR review. It will be publicized on Twitter by [a bot](https://twitter.com/ArrPreprints).
-- Authors may not make a non-anonymized version of their paper available online to the general community (for example, via a preprint server) during the anonymity period. By a version of a paper, we mean another paper having essentially the same scientific content but possibly differing in minor details (including title and structure) and/or in length.
-- If the authors have posted a non-anonymized version of their paper online before the start of the anonymity period, they may submit an anonymized version to ARR. The submitted version must not refer to the non-anonymized version, and the authors must inform the editors-in-chief that a non-anonymized version exists.
-- Authors may not update the non-anonymized version during the anonymity period, and we ask authors not to advertise it on social media or take other actions that would further compromise two-way anonymized reviewing during the anonymity period.
-- Note that, while authors are not prohibited from making a non-anonymous version available online before the start of the anonymity period, this does make two-way anonymized reviewing more difficult to maintain, and we therefore encourage authors to wait. Alternatively, authors may consider submitting their work to the Computational Linguistics journal, which does not require anonymization and has a track for “short” (i.e., conference-length) papers.
-
 ### Instructions for Two-Way Anonymized Review
 
 Papers must not include authors’ names and affiliations. Furthermore, self-references that reveal the authors’ identities, e.g., “We previously showed (Smith, 1991) …” must be avoided. Instead, use citations such as “Smith previously showed (Smith, 1991) …” Papers should not refer, for further detail, to documents that are not available to the reviewers.
@@ -82,6 +66,8 @@ Papers must not include authors’ names and affiliations. Furthermore, self-ref
 Supplementary materials should also be anonymized. This includes author responses during the review process.
 
 Submissions that violate these requirements will be desk rejected.
+
+ARR is subject to the [ACL Policies for Review and Citation](https://www.aclweb.org/adminwiki/index.php/ACL_Policies_for_Review_and_Citation), which were updated in early 2024. Beginning with the February 15, 2024 ARR deadlines, there is no anonymity period or limitation on posting or discussing non-anonymous preprints while the work is under peer review.
 
 ### Authorship
 
@@ -97,7 +83,7 @@ In cases where a preprint has been superseded by a refereed publication, the ref
 
 Papers (whether refereed or not) appearing less than 3 months before the submission deadline are considered contemporaneous to a submission, and authors are therefore not obliged to make detailed comparisons that require additional experimentation and/or in-depth analysis.
 
-For more information, see the [ACL Policies for Submission, Review, and Citation](https://www.aclweb.org/adminwiki/index.php?title=ACL_Policies_for_Submission,_Review_and_Citation).
+For more information, see the [ACL Policies for Review and Citation](https://www.aclweb.org/adminwiki/index.php?title=ACL_Policies_for_Review_and_Citation).
 
 ### Multiple Submission Policy
 

--- a/reviewertutorial.md
+++ b/reviewertutorial.md
@@ -78,7 +78,7 @@ The good news is that the less-than-perfect matches also have upsides: you get t
 
 The second thing to check is whether **you know or can guess who the authors are.** Ideally, ARR peer review should be fully anonymous. The problem with implicit social biases is that they are unconscious; we may be 100% sure that we do not think worse of a paper just because it is written by someone from a group minoritized in computing research, and that we are not pre-disposed to like papers coming from famous labs, but we cannot really trust our conscious selves.
 
-Thus, when you get the assignment, do check that [anonymity is preserved](https://www.aclweb.org/adminwiki/index.php?title=ACL_Policies_for_Submission,_Review_and_Citation). If it is not, the paper should be **desk-rejected**: contact your action editor about this. You can also indicate that the paper should be desk-rejected if it does not follow the style guides or goes over the page limit (which does _not_ include the ethical considerations section). 
+Thus, when you get the assignment, do check that [anonymity is preserved](https://www.aclweb.org/adminwiki/index.php?title=ACL_Policies_for_Review_and_Citation). If it is not, the paper should be **desk-rejected**: contact your action editor about this. You can also indicate that the paper should be desk-rejected if it does not follow the style guides or goes over the page limit (which does _not_ include the ethical considerations section).
 
 If anonymity is preserved, but you happen to know who the authors are from personal communication, social media or talks, ask for re-assignment if possible, especially if you have a conflict of interest (because you know the authors personally, have or will work with them etc.). For the papers where it is impossible to maintain anonymity (e.g., because they are [too famous](https://medium.com/@ryancotterell/we-should-anonymize-model-names-during-peer-review-bcab0cc78946), or the authors are easy to guess for anyone who works in the same narrow subfield), the ARR policy is to indicate your awareness of the authors' identity in the review form (more on that later).
 
@@ -253,7 +253,7 @@ Here is a list of such heuristics derived from author complaints in recent NLP c
   <tr>
    <td>The paper is missing the comparison to the [latest X]
    </td>
-   <td>Per <a href="https://www.aclweb.org/adminwiki/index.php?title=ACL_Policies_for_Submission,_Review_and_Citation">ACL policy</a>, the authors are not obliged to draw comparisons with contemporaneous work, i.e., work published within three months before the submission (or three months before a re-submission). 
+   <td>Per <a href="https://www.aclweb.org/adminwiki/index.php?title=ACL_Policies_for_Review_and_Citation">ACL policy</a>, the authors are not obliged to draw comparisons with contemporaneous work, i.e., work published within three months before the submission (or three months before a re-submission). 
    </td>
   </tr>
   <tr>

--- a/reviewform.md
+++ b/reviewform.md
@@ -114,8 +114,8 @@ If the authors state (in anonymous fashion) that their software will be availabl
 
 ### Knowledge of/educated guess at author identity  
 
-* 5 = From a violation of the anonymity-window or other double-blind-submission rules, I know/can guess at least one author's name.
-* 4 = From an allowed pre-existing preprint or workshop paper, I know/can guess at least one author's name.
+* 5 = From a violation of double-blind-submission rules, I know/can guess at least one author's name. (Note that non-anonymous preprints are permitted at any time, so this is not a violation.)
+* 4 = From a preprint or allowed workshop paper, I know/can guess at least one author's name.
 * 3 = From the contents of the submission itself, I know/can guess at least one author's name.
 * 2 = From social media/a talk/other informal communication, I know/can guess at least one author's name.
 * 1 = I do not have even an educated guess about author identity.

--- a/reviewing.md
+++ b/reviewing.md
@@ -22,7 +22,6 @@ Below is an approximate timeline for the February ARR review cycle. The other cy
 
 Month (example) | Date / Date range | What | Who
 ----------------------------- | ---- | ---- | ---
-January | 15 | Beginning of anonymity period | authors
 February | 1 | Submission site opens | authors
 February | 10 | Confirm availability to review | reviewers + AEs
 February | 15 | **Submission deadline** | authors


### PR DESCRIPTION
In light of the [ACL Anonymity Policy change](https://www.aclweb.org/adminwiki/index.php/ACL_Anonymity_Policy), I've drafted a blog post and new language for the CFP, author/reviewer pages, and review form for consideration by ARR policymakers. I figure time is of the essence because the anonymity period for the next cycle would start on Jan. 15 if it hadn't been for the policy change.