### PR TITLE
Added the details of the ML4AL ACL 2024 workshop

### DIFF
--- a/dates.md
+++ b/dates.md
@@ -39,6 +39,8 @@ Current publication venues participating in ARR are listed below. If you represe
 | [ArabicNLP 2024](https://arabicnlp2024.sigarab.org/) | February 15th, 2024 | May 17th, 2024 |
 | [CMCL 2024](https://cmclorg.github.io/) | February 15th, 2024 | May 17th, 2024 |
 | [SDProc 2024](https://sdproc.org/2024/index.html) | February 15th, 2024 | May 17th, 2024 |
+| [ML4AL 2024](https://www.ml4al.com/) | February 15th, 2024 | May 17th, 2024 |
+
 
 ## Past Venues that Accepted ARR Submissions
 


### PR DESCRIPTION
Added the details of ML4AL 2024, https://www.ml4al.com, with submission deadline on February 15th, 2024  and commitment deadline on May 17th, 2024.