### PR TITLE
Add CoNLL 2024 to dates.md

### DIFF
--- a/dates.md
+++ b/dates.md
@@ -41,6 +41,7 @@ Current publication venues participating in ARR are listed below. If you represe
 | [IWSLT 2024](https://iwslt.org) | February 15th, 2024 | May 28th, 2024 |
 | [INLG 2024](https://inlg2024.github.io/) | April 15th, 2024 | June 15th, 2024 |
 | [EMNLP 2024](https://2024.emnlp.org/) | June 15th, 2024 | August 20th, 2024 |
+| [CoNLL 2024](https://conll.org/2024) | June 15th, 2024 | August 30th, 2024 |
 
 ## Past Venues that Accepted ARR Submissions
 


### PR DESCRIPTION
I'm Julia Watson, a publication chair for CoNLL 2024, and I would like to add our venue to the list of current participating venues.